### PR TITLE
Added Balsamiq Mockups template

### DIFF
--- a/templates/balsamiq/960_mockups.bmml
+++ b/templates/balsamiq/960_mockups.bmml
@@ -1,208 +1,414 @@
-<mockup version="1.0" skin="sketch" measuredW="1000" measuredH="683" mockupW="940" mockupH="623">
+<mockup version="1.0" skin="sketch" measuredW="1010" measuredH="1180" mockupW="960" mockupH="1167">
   <controls>
-    <control controlID="44" controlTypeID="__group__" x="50" y="50" w="-1" h="-1" measuredW="940" measuredH="300" zOrder="0" locked="false" isInGroup="-1">
+    <control controlID="64" controlTypeID="com.balsamiq.mockups::Canvas" x="40" y="850" w="960" h="320" measuredW="100" measuredH="70" zOrder="4" locked="false" isInGroup="-1"/>
+    <control controlID="105" controlTypeID="__group__" x="45" y="860" w="-1" h="-1" measuredW="950" measuredH="300" zOrder="5" locked="false" isInGroup="-1">
+      <groupChildrenDescriptors>
+        <control controlID="66" controlTypeID="com.balsamiq.mockups::Canvas" x="0" y="0" w="30" h="300" measuredW="100" measuredH="70" zOrder="0" locked="false" isInGroup="105">
+          <controlProperties>
+            <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
+          </controlProperties>
+        </control>
+        <control controlID="82" controlTypeID="com.balsamiq.mockups::Canvas" x="40" y="0" w="30" h="300" measuredW="100" measuredH="70" zOrder="1" locked="false" isInGroup="105">
+          <controlProperties>
+            <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
+          </controlProperties>
+        </control>
+        <control controlID="83" controlTypeID="com.balsamiq.mockups::Canvas" x="80" y="0" w="30" h="300" measuredW="100" measuredH="70" zOrder="2" locked="false" isInGroup="105">
+          <controlProperties>
+            <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
+          </controlProperties>
+        </control>
+        <control controlID="84" controlTypeID="com.balsamiq.mockups::Canvas" x="120" y="0" w="30" h="300" measuredW="100" measuredH="70" zOrder="3" locked="false" isInGroup="105">
+          <controlProperties>
+            <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
+          </controlProperties>
+        </control>
+        <control controlID="85" controlTypeID="com.balsamiq.mockups::Canvas" x="160" y="0" w="30" h="300" measuredW="100" measuredH="70" zOrder="4" locked="false" isInGroup="105">
+          <controlProperties>
+            <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
+          </controlProperties>
+        </control>
+        <control controlID="86" controlTypeID="com.balsamiq.mockups::Canvas" x="200" y="0" w="30" h="300" measuredW="100" measuredH="70" zOrder="5" locked="false" isInGroup="105">
+          <controlProperties>
+            <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
+          </controlProperties>
+        </control>
+        <control controlID="87" controlTypeID="com.balsamiq.mockups::Canvas" x="240" y="0" w="30" h="300" measuredW="100" measuredH="70" zOrder="6" locked="false" isInGroup="105">
+          <controlProperties>
+            <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
+          </controlProperties>
+        </control>
+        <control controlID="88" controlTypeID="com.balsamiq.mockups::Canvas" x="280" y="0" w="30" h="300" measuredW="100" measuredH="70" zOrder="7" locked="false" isInGroup="105">
+          <controlProperties>
+            <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
+          </controlProperties>
+        </control>
+        <control controlID="89" controlTypeID="com.balsamiq.mockups::Canvas" x="320" y="0" w="30" h="300" measuredW="100" measuredH="70" zOrder="8" locked="false" isInGroup="105">
+          <controlProperties>
+            <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
+          </controlProperties>
+        </control>
+        <control controlID="90" controlTypeID="com.balsamiq.mockups::Canvas" x="360" y="0" w="30" h="300" measuredW="100" measuredH="70" zOrder="9" locked="false" isInGroup="105">
+          <controlProperties>
+            <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
+          </controlProperties>
+        </control>
+        <control controlID="91" controlTypeID="com.balsamiq.mockups::Canvas" x="400" y="0" w="30" h="300" measuredW="100" measuredH="70" zOrder="10" locked="false" isInGroup="105">
+          <controlProperties>
+            <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
+          </controlProperties>
+        </control>
+        <control controlID="92" controlTypeID="com.balsamiq.mockups::Canvas" x="440" y="0" w="30" h="300" measuredW="100" measuredH="70" zOrder="11" locked="false" isInGroup="105">
+          <controlProperties>
+            <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
+          </controlProperties>
+        </control>
+        <control controlID="93" controlTypeID="com.balsamiq.mockups::Canvas" x="480" y="0" w="30" h="300" measuredW="100" measuredH="70" zOrder="12" locked="false" isInGroup="105">
+          <controlProperties>
+            <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
+          </controlProperties>
+        </control>
+        <control controlID="94" controlTypeID="com.balsamiq.mockups::Canvas" x="520" y="0" w="30" h="300" measuredW="100" measuredH="70" zOrder="13" locked="false" isInGroup="105">
+          <controlProperties>
+            <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
+          </controlProperties>
+        </control>
+        <control controlID="95" controlTypeID="com.balsamiq.mockups::Canvas" x="560" y="0" w="30" h="300" measuredW="100" measuredH="70" zOrder="14" locked="false" isInGroup="105">
+          <controlProperties>
+            <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
+          </controlProperties>
+        </control>
+        <control controlID="96" controlTypeID="com.balsamiq.mockups::Canvas" x="600" y="0" w="30" h="300" measuredW="100" measuredH="70" zOrder="15" locked="false" isInGroup="105">
+          <controlProperties>
+            <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
+          </controlProperties>
+        </control>
+        <control controlID="97" controlTypeID="com.balsamiq.mockups::Canvas" x="640" y="0" w="30" h="300" measuredW="100" measuredH="70" zOrder="16" locked="false" isInGroup="105">
+          <controlProperties>
+            <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
+          </controlProperties>
+        </control>
+        <control controlID="98" controlTypeID="com.balsamiq.mockups::Canvas" x="680" y="0" w="30" h="300" measuredW="100" measuredH="70" zOrder="17" locked="false" isInGroup="105">
+          <controlProperties>
+            <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
+          </controlProperties>
+        </control>
+        <control controlID="99" controlTypeID="com.balsamiq.mockups::Canvas" x="720" y="0" w="30" h="300" measuredW="100" measuredH="70" zOrder="18" locked="false" isInGroup="105">
+          <controlProperties>
+            <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
+          </controlProperties>
+        </control>
+        <control controlID="100" controlTypeID="com.balsamiq.mockups::Canvas" x="760" y="0" w="30" h="300" measuredW="100" measuredH="70" zOrder="19" locked="false" isInGroup="105">
+          <controlProperties>
+            <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
+          </controlProperties>
+        </control>
+        <control controlID="101" controlTypeID="com.balsamiq.mockups::Canvas" x="800" y="0" w="30" h="300" measuredW="100" measuredH="70" zOrder="20" locked="false" isInGroup="105">
+          <controlProperties>
+            <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
+          </controlProperties>
+        </control>
+        <control controlID="102" controlTypeID="com.balsamiq.mockups::Canvas" x="840" y="0" w="30" h="300" measuredW="100" measuredH="70" zOrder="21" locked="false" isInGroup="105">
+          <controlProperties>
+            <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
+          </controlProperties>
+        </control>
+        <control controlID="103" controlTypeID="com.balsamiq.mockups::Canvas" x="880" y="0" w="30" h="300" measuredW="100" measuredH="70" zOrder="22" locked="false" isInGroup="105">
+          <controlProperties>
+            <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
+          </controlProperties>
+        </control>
+        <control controlID="104" controlTypeID="com.balsamiq.mockups::Canvas" x="920" y="0" w="30" h="300" measuredW="100" measuredH="70" zOrder="23" locked="false" isInGroup="105">
+          <controlProperties>
+            <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
+          </controlProperties>
+        </control>
+      </groupChildrenDescriptors>
+    </control>
+    <control controlID="106" controlTypeID="com.balsamiq.mockups::Label" x="431" y="50" w="178" h="29" measuredW="168" measuredH="37" zOrder="6" locked="false" isInGroup="-1">
+      <controlProperties>
+        <align>center</align>
+        <text>12-Column%20Grid</text>
+        <size>24</size>
+      </controlProperties>
+    </control>
+    <control controlID="107" controlTypeID="com.balsamiq.mockups::Label" x="431" y="430" w="178" h="29" measuredW="169" measuredH="37" zOrder="7" locked="false" isInGroup="-1">
+      <controlProperties>
+        <align>center</align>
+        <size>24</size>
+        <text>16-Column%20Grid</text>
+      </controlProperties>
+    </control>
+    <control controlID="44" controlTypeID="__group__" x="50" y="100" w="-1" h="-1" measuredW="940" measuredH="300" zOrder="2" locked="false" isInGroup="-1">
       <groupChildrenDescriptors>
         <control controlID="32" controlTypeID="com.balsamiq.mockups::Canvas" x="0" y="0" w="60" h="300" measuredW="100" measuredH="70" zOrder="0" locked="false" isInGroup="44">
           <controlProperties>
-            <borderStyle>none</borderStyle>
-            <color>11776947</color>
             <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
           </controlProperties>
         </control>
         <control controlID="33" controlTypeID="com.balsamiq.mockups::Canvas" x="80" y="0" w="60" h="300" measuredW="100" measuredH="70" zOrder="1" locked="false" isInGroup="44">
           <controlProperties>
-            <borderStyle>none</borderStyle>
-            <color>11776947</color>
             <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
           </controlProperties>
         </control>
         <control controlID="34" controlTypeID="com.balsamiq.mockups::Canvas" x="160" y="0" w="60" h="300" measuredW="100" measuredH="70" zOrder="2" locked="false" isInGroup="44">
           <controlProperties>
-            <borderStyle>none</borderStyle>
-            <color>11776947</color>
             <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
           </controlProperties>
         </control>
         <control controlID="35" controlTypeID="com.balsamiq.mockups::Canvas" x="240" y="0" w="60" h="300" measuredW="100" measuredH="70" zOrder="3" locked="false" isInGroup="44">
           <controlProperties>
-            <borderStyle>none</borderStyle>
-            <color>11776947</color>
             <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
           </controlProperties>
         </control>
         <control controlID="36" controlTypeID="com.balsamiq.mockups::Canvas" x="320" y="0" w="60" h="300" measuredW="100" measuredH="70" zOrder="4" locked="false" isInGroup="44">
           <controlProperties>
-            <borderStyle>none</borderStyle>
-            <color>11776947</color>
             <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
           </controlProperties>
         </control>
         <control controlID="37" controlTypeID="com.balsamiq.mockups::Canvas" x="400" y="0" w="60" h="300" measuredW="100" measuredH="70" zOrder="5" locked="false" isInGroup="44">
           <controlProperties>
-            <borderStyle>none</borderStyle>
-            <color>11776947</color>
             <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
           </controlProperties>
         </control>
         <control controlID="38" controlTypeID="com.balsamiq.mockups::Canvas" x="480" y="0" w="60" h="300" measuredW="100" measuredH="70" zOrder="6" locked="false" isInGroup="44">
           <controlProperties>
-            <borderStyle>none</borderStyle>
-            <color>11776947</color>
             <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
           </controlProperties>
         </control>
         <control controlID="39" controlTypeID="com.balsamiq.mockups::Canvas" x="560" y="0" w="60" h="300" measuredW="100" measuredH="70" zOrder="7" locked="false" isInGroup="44">
           <controlProperties>
-            <borderStyle>none</borderStyle>
-            <color>11776947</color>
             <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
           </controlProperties>
         </control>
         <control controlID="40" controlTypeID="com.balsamiq.mockups::Canvas" x="640" y="0" w="60" h="300" measuredW="100" measuredH="70" zOrder="8" locked="false" isInGroup="44">
           <controlProperties>
-            <borderStyle>none</borderStyle>
-            <color>11776947</color>
             <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
           </controlProperties>
         </control>
         <control controlID="41" controlTypeID="com.balsamiq.mockups::Canvas" x="720" y="0" w="60" h="300" measuredW="100" measuredH="70" zOrder="9" locked="false" isInGroup="44">
           <controlProperties>
-            <borderStyle>none</borderStyle>
-            <color>11776947</color>
             <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
           </controlProperties>
         </control>
         <control controlID="42" controlTypeID="com.balsamiq.mockups::Canvas" x="800" y="0" w="60" h="300" measuredW="100" measuredH="70" zOrder="10" locked="false" isInGroup="44">
           <controlProperties>
-            <borderStyle>none</borderStyle>
-            <color>11776947</color>
             <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
           </controlProperties>
         </control>
         <control controlID="43" controlTypeID="com.balsamiq.mockups::Canvas" x="880" y="0" w="60" h="300" measuredW="100" measuredH="70" zOrder="11" locked="false" isInGroup="44">
           <controlProperties>
-            <borderStyle>none</borderStyle>
-            <color>11776947</color>
             <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
           </controlProperties>
         </control>
       </groupChildrenDescriptors>
     </control>
-    <control controlID="61" controlTypeID="__group__" x="50" y="373" w="-1" h="-1" measuredW="940" measuredH="300" zOrder="1" locked="false" isInGroup="-1">
+    <control controlID="109" controlTypeID="com.balsamiq.mockups::Label" x="342" y="3" w="-1" h="-1" measuredW="356" measuredH="41" zOrder="9" locked="false" isInGroup="-1">
+      <controlProperties>
+        <text>960%20Grid%20Balsamiq%20Mockups</text>
+        <size>28</size>
+      </controlProperties>
+    </control>
+    <control controlID="108" controlTypeID="com.balsamiq.mockups::Label" x="431" y="810" w="178" h="29" measuredW="173" measuredH="37" zOrder="8" locked="false" isInGroup="-1">
+      <controlProperties>
+        <align>center</align>
+        <text>24-Column%20Grid</text>
+        <size>24</size>
+      </controlProperties>
+    </control>
+    <control controlID="61" controlTypeID="__group__" x="50" y="480" w="-1" h="-1" measuredW="940" measuredH="300" zOrder="3" locked="false" isInGroup="-1">
       <groupChildrenDescriptors>
         <control controlID="45" controlTypeID="com.balsamiq.mockups::Canvas" x="0" y="0" w="40" h="300" measuredW="100" measuredH="70" zOrder="0" locked="false" isInGroup="61">
           <controlProperties>
-            <borderStyle>none</borderStyle>
-            <color>11776947</color>
             <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
           </controlProperties>
         </control>
         <control controlID="46" controlTypeID="com.balsamiq.mockups::Canvas" x="60" y="0" w="40" h="300" measuredW="100" measuredH="70" zOrder="1" locked="false" isInGroup="61">
           <controlProperties>
-            <borderStyle>none</borderStyle>
-            <color>11776947</color>
             <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
           </controlProperties>
         </control>
         <control controlID="47" controlTypeID="com.balsamiq.mockups::Canvas" x="120" y="0" w="40" h="300" measuredW="100" measuredH="70" zOrder="2" locked="false" isInGroup="61">
           <controlProperties>
-            <borderStyle>none</borderStyle>
-            <color>11776947</color>
             <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
           </controlProperties>
         </control>
         <control controlID="48" controlTypeID="com.balsamiq.mockups::Canvas" x="180" y="0" w="40" h="300" measuredW="100" measuredH="70" zOrder="3" locked="false" isInGroup="61">
           <controlProperties>
-            <borderStyle>none</borderStyle>
-            <color>11776947</color>
             <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
           </controlProperties>
         </control>
         <control controlID="49" controlTypeID="com.balsamiq.mockups::Canvas" x="240" y="0" w="40" h="300" measuredW="100" measuredH="70" zOrder="4" locked="false" isInGroup="61">
           <controlProperties>
-            <borderStyle>none</borderStyle>
-            <color>11776947</color>
             <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
           </controlProperties>
         </control>
         <control controlID="50" controlTypeID="com.balsamiq.mockups::Canvas" x="300" y="0" w="40" h="300" measuredW="100" measuredH="70" zOrder="5" locked="false" isInGroup="61">
           <controlProperties>
-            <borderStyle>none</borderStyle>
-            <color>11776947</color>
             <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
           </controlProperties>
         </control>
         <control controlID="51" controlTypeID="com.balsamiq.mockups::Canvas" x="360" y="0" w="40" h="300" measuredW="100" measuredH="70" zOrder="6" locked="false" isInGroup="61">
           <controlProperties>
-            <borderStyle>none</borderStyle>
-            <color>11776947</color>
             <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
           </controlProperties>
         </control>
         <control controlID="52" controlTypeID="com.balsamiq.mockups::Canvas" x="420" y="0" w="40" h="300" measuredW="100" measuredH="70" zOrder="7" locked="false" isInGroup="61">
           <controlProperties>
-            <borderStyle>none</borderStyle>
-            <color>11776947</color>
             <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
           </controlProperties>
         </control>
         <control controlID="53" controlTypeID="com.balsamiq.mockups::Canvas" x="480" y="0" w="40" h="300" measuredW="100" measuredH="70" zOrder="8" locked="false" isInGroup="61">
           <controlProperties>
-            <borderStyle>none</borderStyle>
-            <color>11776947</color>
             <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
           </controlProperties>
         </control>
         <control controlID="54" controlTypeID="com.balsamiq.mockups::Canvas" x="540" y="0" w="40" h="300" measuredW="100" measuredH="70" zOrder="9" locked="false" isInGroup="61">
           <controlProperties>
-            <borderStyle>none</borderStyle>
-            <color>11776947</color>
             <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
           </controlProperties>
         </control>
         <control controlID="55" controlTypeID="com.balsamiq.mockups::Canvas" x="600" y="0" w="40" h="300" measuredW="100" measuredH="70" zOrder="10" locked="false" isInGroup="61">
           <controlProperties>
-            <borderStyle>none</borderStyle>
-            <color>11776947</color>
             <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
           </controlProperties>
         </control>
         <control controlID="56" controlTypeID="com.balsamiq.mockups::Canvas" x="660" y="0" w="40" h="300" measuredW="100" measuredH="70" zOrder="11" locked="false" isInGroup="61">
           <controlProperties>
-            <borderStyle>none</borderStyle>
-            <color>11776947</color>
             <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
           </controlProperties>
         </control>
         <control controlID="57" controlTypeID="com.balsamiq.mockups::Canvas" x="720" y="0" w="40" h="300" measuredW="100" measuredH="70" zOrder="12" locked="false" isInGroup="61">
           <controlProperties>
-            <borderStyle>none</borderStyle>
-            <color>11776947</color>
             <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
           </controlProperties>
         </control>
         <control controlID="58" controlTypeID="com.balsamiq.mockups::Canvas" x="780" y="0" w="40" h="300" measuredW="100" measuredH="70" zOrder="13" locked="false" isInGroup="61">
           <controlProperties>
-            <borderStyle>none</borderStyle>
-            <color>11776947</color>
             <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
           </controlProperties>
         </control>
         <control controlID="59" controlTypeID="com.balsamiq.mockups::Canvas" x="840" y="0" w="40" h="300" measuredW="100" measuredH="70" zOrder="14" locked="false" isInGroup="61">
           <controlProperties>
-            <borderStyle>none</borderStyle>
-            <color>11776947</color>
             <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
           </controlProperties>
         </control>
         <control controlID="60" controlTypeID="com.balsamiq.mockups::Canvas" x="900" y="0" w="40" h="300" measuredW="100" measuredH="70" zOrder="15" locked="false" isInGroup="61">
           <controlProperties>
-            <borderStyle>none</borderStyle>
-            <color>11776947</color>
             <backgroundAlpha>0.25</backgroundAlpha>
+            <color>11776947</color>
+            <borderStyle>none</borderStyle>
           </controlProperties>
         </control>
       </groupChildrenDescriptors>
     </control>
+    <control controlID="62" controlTypeID="com.balsamiq.mockups::Canvas" x="40" y="90" w="960" h="320" measuredW="100" measuredH="70" zOrder="1" locked="false" isInGroup="-1">
+      <controlProperties>
+        <borderStyle>square</borderStyle>
+      </controlProperties>
+    </control>
+    <control controlID="63" controlTypeID="com.balsamiq.mockups::Canvas" x="40" y="470" w="960" h="320" measuredW="100" measuredH="70" zOrder="0" locked="false" isInGroup="-1"/>
   </controls>
 </mockup>


### PR DESCRIPTION
I added this Balsamiq Mockups template, which is a modified version of the file posted at http://community.balsamiq.com/balsamiq/topics/provide_a_960_grid_background which didn't seem to have the 10px margin on the left and right columns.
